### PR TITLE
Added missing transitive dependency

### DIFF
--- a/DemoApp/build.gradle
+++ b/DemoApp/build.gradle
@@ -87,6 +87,7 @@ dependencies {
     // Reference the AccuTerra SDK library
     implementation "com.accuterra:accuterra-android-sdk:0.40.0"
     implementation "com.accuterra:accuterra-android-sdk-core:0.40.0"
+    implementation "com.accuterra:accuterra-android-location-service:0.40.0"
     // Download also sources and javadoc for easier orientation - just for the development!
     // implementation "com.accuterra:accuterra-android-sdk:0.40.0:sources"
     // implementation "com.accuterra:accuterra-android-sdk:0.40.0:javadoc"


### PR DESCRIPTION
Explicitly add transitive dependency for accuterra-android-location-service into the demo app.